### PR TITLE
Adds Digital Ocean Terraform for creating Chef Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.vagrant
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Terraform
+*.tfstate
+*.tfstate*
+.terraform
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 *.tfstate*
 .terraform
 
+###
+# Ignore Chef key files and secrets
+###
+*.pem
+config.rb
+*.crt

--- a/terraform/digital-ocean/.chef/config-example.rb
+++ b/terraform/digital-ocean/.chef/config-example.rb
@@ -1,0 +1,7 @@
+current_dir = File.dirname(__FILE__)
+client_key "#{current_dir}/chefmigration.pem"
+validation_client_name 'chefmigration-validator'
+validation_key "#{current_dir}/chefmigration-validator.pem"
+ssl_verify_mode :verify_none
+node_name 'chefmigration'
+chef_server_url 'https://134.209.170.12/organizations/chefmigration'

--- a/terraform/digital-ocean/README.md
+++ b/terraform/digital-ocean/README.md
@@ -1,0 +1,45 @@
+# Chef Server Terraform for Digital Ocean
+
+## Prerequisites
+```shell
+brew install terraform # install Terraform using homebrew
+```
+
+## Getting Started
+1. Set your `do_api_token` environment variable to interact with Digital Ocean's API.
+```shell
+$ export TF_VAR_do_api_token=yourdigitaloceanapiwithoutquotes
+```
+
+2. Change into the `terraform/digital-ocean` directory.
+```shell
+$ cd ~/path/to/repo/upgrade-migration-environment/terraform/digital-ocean
+```
+
+3. Update `variables.tf` with the information used for provisioning.
+```
+$ vim variables.tf
+```
+
+4. Run terraform commands.
+```
+$ terraform init
+$ terraform validate
+$ terraform plan
+$ terraform apply
+```
+
+5. After the terraform applies successfully, copy the keys and `config.rb` to your local workstation. You'll need to replace `chef_server-public_ipv4` with the public IP that is in the output of the terraform run.
+```shell
+$ mkdir -p ~/.chef
+$ scp root@chef_server-public_ipv4:"/tmp/*.pem /tmp/config.rb" ~/.chef/
+```
+
+6. Knife commands!
+```
+$ cd ~/.chef
+$ knife ssl fetch
+$ knife client list
+```
+
+If all goes well, you're communicating with the Chef Server.

--- a/terraform/digital-ocean/README.md
+++ b/terraform/digital-ocean/README.md
@@ -16,11 +16,6 @@ $ export TF_VAR_do_api_token=yourdigitaloceanapiwithoutquotes
 $ cd ~/path/to/repo/upgrade-migration-environment/terraform/digital-ocean
 ```
 
-3. Update `variables.tf` with the information used for provisioning.
-```
-$ vim variables.tf
-```
-
 4. Run terraform commands.
 ```
 $ terraform init
@@ -29,16 +24,13 @@ $ terraform plan
 $ terraform apply
 ```
 
-5. After the terraform applies successfully, copy the keys and `config.rb` to your local workstation. You'll need to replace `chef_server-public_ipv4` with the public IP that is in the output of the terraform run.
+5. After the terraform applies successfully it outputs an SCP command to download the credentials to communicate with the chef-server. The command should be copied and run from your terminal and looks something like this:
 ```shell
-$ scp root@chef_server-public_ipv4:"/tmp/*.pem /tmp/config.rb" .chef/
+$ scp root@CHEFSERVERIPADDRESS:"/tmp/*.pem /tmp/config.rb" .chef/
 ```
 
-6. Knife commands!
+6. Now knife commands that communicate with the Chef Server should work.
 ```
-$ cd ~/.chef
 $ knife ssl fetch
 $ knife client list
 ```
-
-If all goes well, you're communicating with the Chef Server.

--- a/terraform/digital-ocean/README.md
+++ b/terraform/digital-ocean/README.md
@@ -31,8 +31,7 @@ $ terraform apply
 
 5. After the terraform applies successfully, copy the keys and `config.rb` to your local workstation. You'll need to replace `chef_server-public_ipv4` with the public IP that is in the output of the terraform run.
 ```shell
-$ mkdir -p ~/.chef
-$ scp root@chef_server-public_ipv4:"/tmp/*.pem /tmp/config.rb" ~/.chef/
+$ scp root@chef_server-public_ipv4:"/tmp/*.pem /tmp/config.rb" .chef/
 ```
 
 6. Knife commands!

--- a/terraform/digital-ocean/chef-server.tf
+++ b/terraform/digital-ocean/chef-server.tf
@@ -1,0 +1,77 @@
+# chef_userdata template
+data "template_file" "chef_userdata" {
+  template = "${file("../templates/chef_userdata.tpl")}"
+
+  vars = {
+    domain_name = "${var.domain_name}"
+  }
+}
+
+# chef_bootstrap template
+data "template_file" "chef_bootstrap" {
+  template = "${file("../templates/chef_bootstrap.tpl")}"
+
+  vars = {
+    chef_user_id       = "${var.chef_user_id}"
+    chef_user_name     = "${var.chef_user_name}"
+    chef_user_password = "${var.chef_user_password}"
+    chef_user_email    = "${var.chef_user_email}"
+    chef_org_shortname = "${var.chef_org_shortname}"
+    chef_org_longname  = "${var.chef_org_longname}"
+  }
+}
+
+# chef_configrb template
+data "template_file" "chef_configrb" {
+  template = "${file("../templates/chef_configrb.tpl")}"
+
+  vars = {
+    chef_user_id       = "${var.chef_user_id}"
+    chef_org_shortname = "${var.chef_org_shortname}"
+  }
+}
+
+# Add SSH Key
+resource "digitalocean_ssh_key" "user" {
+  name       = "${var.chef_user_email}"
+  public_key = "${file(var.public_key)}"
+}
+
+# Create Droplet
+resource "digitalocean_droplet" "chef-server" {
+  image  = "centos-7-x64"
+  name   = "chef-server"
+  private_networking = true
+  region = "nyc3"
+  size   = "s-4vcpu-8gb"
+  ssh_keys = [
+    "${digitalocean_ssh_key.user.fingerprint}"
+  ]
+
+  provisioner "file" {
+    connection {
+      host = "${self.ipv4_address}"
+      user = "root"
+      type = "ssh"
+      private_key = "${file(var.private_key)}"
+    }
+    content     = "${data.template_file.chef_configrb.rendered}"
+    destination = "/tmp/config.rb"
+  }
+
+  provisioner "remote-exec" {
+    connection {
+      host = "${self.ipv4_address}"
+      user = "root"
+      type = "ssh"
+      private_key = "${file(var.private_key)}"
+    }
+    inline = [
+      "echo '${data.template_file.chef_bootstrap.rendered}' > /tmp/bootstrap-chef-server.sh",
+      "chmod +x /tmp/bootstrap-chef-server.sh",
+      "sudo sh /tmp/bootstrap-chef-server.sh",
+      "echo \"chef_server_url 'https://${self.ipv4_address}/organizations/${var.chef_org_shortname}'\" >> /tmp/config.rb"
+    ]
+  }
+  user_data = "${data.template_file.chef_userdata.rendered}"
+}

--- a/terraform/digital-ocean/outputs.tf
+++ b/terraform/digital-ocean/outputs.tf
@@ -1,8 +1,4 @@
 # Chef Server
-output "chef_server-public_ipv4" {
-  value = "${digitalocean_droplet.chef-server.ipv4_address}"
-}
-
-output "chef_server-private_ipv4" {
-  value = "${digitalocean_droplet.chef-server.ipv4_address_private}"
+output "download_chef_server_credentials" {
+  value = "scp root@${digitalocean_droplet.chef-server.ipv4_address}:'/tmp/*.pem /tmp/config.rb' .chef/"
 }

--- a/terraform/digital-ocean/outputs.tf
+++ b/terraform/digital-ocean/outputs.tf
@@ -1,0 +1,8 @@
+# Chef Server
+output "chef_server-public_ipv4" {
+  value = "${digitalocean_droplet.chef-server.ipv4_address}"
+}
+
+output "chef_server-private_ipv4" {
+  value = "${digitalocean_droplet.chef-server.ipv4_address_private}"
+}

--- a/terraform/digital-ocean/provider.tf
+++ b/terraform/digital-ocean/provider.tf
@@ -1,0 +1,7 @@
+provider "digitalocean" {
+    token = "${var.do_api_token}"
+}
+
+terraform {
+  required_version = "> 0.12.0"
+}

--- a/terraform/digital-ocean/variables.tf
+++ b/terraform/digital-ocean/variables.tf
@@ -1,0 +1,51 @@
+# Provider Info
+variable "do_api_token" {
+  description = "The API token used to interact with the Digital Ocean account."
+  default     = "nil"
+}
+
+# Provisioning Info
+variable "public_key" {
+  description = "Path to the public SSH key needed to access host."
+  default     = "~/.ssh/id_rsa.pub"
+}
+variable "private_key" {
+  description = "Path to the private SSH key needed to access host."
+  default     = "~/.ssh/id_rsa"
+}
+
+# Chef Server
+variable "domain_name" {
+  description = "TLD to use."
+  default     = "some.tld"
+}
+
+variable "chef_user_id" {
+  description = "Username of the first user on chef server to be created."
+  default     = "chefmigration"
+}
+
+variable "chef_user_name" {
+  description = "Firstname / Lastname of the first user to be created."
+  default     = "Chef Migration"
+}
+
+variable "chef_user_password" {
+  description = "Password of the first user to be created."
+  default     = "1234SuperMigrator"
+}
+
+variable "chef_user_email" {
+  description = "E-mail of the first user to be created."
+  default     = "chef@migration.tld"
+}
+
+variable "chef_org_shortname" {
+  description = "Short name of the Chef Organization to be created."
+  default     = "chefmigration"
+}
+
+variable "chef_org_longname" {
+  description = "Long name of the Chef Organization to be created."
+  default     = "Chef Migration Org"
+}

--- a/terraform/templates/chef_bootstrap.tpl
+++ b/terraform/templates/chef_bootstrap.tpl
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+yum install wget -y
+cd /tmp && wget https://packages.chef.io/files/stable/chef-server/13.0.17/el/7/chef-server-core-13.0.17-1.el7.x86_64.rpm
+rpm -Uvh /tmp/chef-server-core-13.0.17-1.el7.x86_64.rpm
+chef-server-ctl reconfigure --chef-license=accept
+chef-server-ctl user-create ${chef_user_id} ${chef_user_name} ${chef_user_email} ${chef_user_password} --filename /tmp/${chef_user_id}.pem
+chef-server-ctl org-create ${chef_org_shortname} "${chef_org_longname}" --association_user ${chef_user_id} --filename /tmp/${chef_org_shortname}-validator.pem
+chef-server-ctl reconfigure
+echo "nginx[\"enable_non_ssl\"] = true" > /etc/opscode/chef-server.rb
+chef-server-ctl reconfigure
+echo "Finished"

--- a/terraform/templates/chef_configrb.tpl
+++ b/terraform/templates/chef_configrb.tpl
@@ -1,0 +1,5 @@
+client_key '~/.chef/${chef_user_id}.pem'
+validation_client_name '${chef_org_shortname}-validator'
+validation_key '~/.chef/${chef_org_shortname}-validator.pem'
+ssl_verify_mode :verify_none
+node_name '${chef_user_id}'

--- a/terraform/templates/chef_configrb.tpl
+++ b/terraform/templates/chef_configrb.tpl
@@ -1,5 +1,6 @@
-client_key '~/.chef/${chef_user_id}.pem'
+current_dir = File.dirname(__FILE__)
+client_key "#{current_dir}/${chef_user_id}.pem"
 validation_client_name '${chef_org_shortname}-validator'
-validation_key '~/.chef/${chef_org_shortname}-validator.pem'
+validation_key "#{current_dir}/${chef_org_shortname}-validator.pem"
 ssl_verify_mode :verify_none
 node_name '${chef_user_id}'

--- a/terraform/templates/chef_userdata.tpl
+++ b/terraform/templates/chef_userdata.tpl
@@ -1,0 +1,8 @@
+#cloud-config
+
+bootcmd:
+ - hostname chef-server.${domain_name}
+ - echo 127.0.1.1 chef chef-server.${domain_name} >> /etc/hosts
+ - echo chef-server.${domain_name} > /etc/hostname
+
+preserve_hostname: true


### PR DESCRIPTION
This PR adds the terraform configs necessary to create a vanilla Chef Server on Digital Ocean. 

To Do:
- [x] SSH Key Addition for Host access
- [x] Droplet Creation of Centos 7 Host
- [x] Installation and vanilla configuration of Chef Server
- [x] Verify `knife` usage
- [x] Fix `config.rb` single quotes 